### PR TITLE
vincula api de best sellers do NYT na view de livros

### DIFF
--- a/src/views/BooksView.vue
+++ b/src/views/BooksView.vue
@@ -2,35 +2,43 @@
 export default {
   data() {
     return {
-      apiKey: 'DfAI0teJCa28uw06owBfsF00xcyXoW7p',
+      apiKey: "DfAI0teJCa28uw06owBfsF00xcyXoW7p",
       books: {
-        info: {}
-      }
+        info: [],
+      },
     };
-  },
-  mounted() {
-    this.getBooks();
   },
   methods: {
     getBooks() {
-      fetch(`https://api.nytimes.com/svc/books/v3/lists/current/hardcover-fiction.json?api-key=${this.apiKey}`)
+      fetch(
+        `https://api.nytimes.com/svc/books/v3/lists/best-sellers/history.json?title=%20&api-key=${this.apiKey}`
+      )
         .then((res) => res.json())
         .then((data) => {
-          this.books.info = {
-            "Display Name": data.results.display_name,
-            "Bestsellers Date": data.results.bestsellers_date,
-            "Published Date": data.results.published_date,
-          };
+          console.log(data);
+          const bookDetails = data.results.map((book) => ({
+            Título: book.title,
+            Autor: book.author,
+            Sinopse: book.description,
+          }));
+          this.books.info = bookDetails;
         });
     },
+  },
+  computed: {},
+  mounted() {
+    this.getBooks();
   },
 };
 </script>
 
 <template>
   <div>
-    <div v-for="(value, label) in books.info" :key="label">
-      {{ label }}: {{ value }}
+    <div v-for="(book, index) in books.info" :key="index">
+      <div v-for="(value, label) in book" :key="label">
+        {{ label }}: {{ value }}
+      </div>
+      <hr />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Este PR vincula o API de best sellers do NYT na view de livros por meio de fetch.