### PR TITLE
mostra best sellers do NYT por categoria

### DIFF
--- a/src/views/BooksView.vue
+++ b/src/views/BooksView.vue
@@ -3,41 +3,69 @@ export default {
   data() {
     return {
       apiKey: "DfAI0teJCa28uw06owBfsF00xcyXoW7p",
-      books: {
-        info: [],
-      },
+      list: [],
+      rankings: {}, // Armazena os rankings de livros por categoria
     };
   },
   methods: {
-    getBooks() {
-      fetch(
-        `https://api.nytimes.com/svc/books/v3/lists/best-sellers/history.json?title=%20&api-key=${this.apiKey}`
-      )
+    getTopics() {
+      fetch(`https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=${this.apiKey}`)
         .then((res) => res.json())
         .then((data) => {
-          console.log(data);
-          const bookDetails = data.results.map((book) => ({
-            Título: book.title,
-            Autor: book.author,
-            Sinopse: book.description,
+          const listTopics = data.results.map((lists) => ({
+            Category: lists.list_name_encoded,
+            Name: lists.display_name,
+            ShowRankings: false, // Propriedade de controle de exibição
           }));
-          this.books.info = bookDetails;
+          this.list = listTopics;
         });
     },
+    getRankings(category) {
+      if (this.rankings[category]) {
+        // Se já tiver os rankings, não precisa fazer a requisição novamente
+        return;
+      }
+
+      fetch(`https://api.nytimes.com/svc/books/v3/lists/current/${category}.json?api-key=${this.apiKey}`)
+        .then((res) => res.json())
+        .then((data) => {
+          const rankings = data.results.books.map((book) => ({
+            Title: book.title,
+            Rank: book.rank,
+          }));
+          this.rankings = {
+            ...this.rankings,
+            [category]: rankings,
+          };
+        });
+    },
+    toggleRankings(category) {
+      const item = this.list.find((item) => item.Category === category);
+      if (item) {
+        item.ShowRankings = !item.ShowRankings;
+        if (item.ShowRankings) {
+          this.getRankings(category);
+        }
+      }
+    },
   },
-  computed: {},
   mounted() {
-    this.getBooks();
+    this.getTopics();
   },
 };
 </script>
 
 <template>
   <div>
-    <div v-for="(book, index) in books.info" :key="index">
-      <div v-for="(value, label) in book" :key="label">
-        {{ label }}: {{ value }}
-      </div>
+    <div v-for="(item, index) in list" :key="index">
+      <h3 @click="toggleRankings(item.Category)">
+        {{ item.Name }}
+      </h3>
+      <ol v-if="rankings[item.Category] && item.ShowRankings">
+        <li v-for="(book, bookIndex) in rankings[item.Category]" :key="bookIndex">
+          {{ book.Title }}
+        </li>
+      </ol>
       <hr />
     </div>
   </div>


### PR DESCRIPTION
Este PR permite a visualização do top15 best sellers do NYT por categoria. Para isso, foi necessário:
--fazer fetch para puxar lista completa de categorias do NYT pela API; e
--fazer outro fetch para puxar - dentro das respectivas categorias - o ranking de livros.